### PR TITLE
Add client-side pagination for image gallery

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -31,6 +31,7 @@
           <p class="gallery-subtitle" id="gallery-subtitle"></p>
         </div>
         <div class="pinterest-grid" id="pinterest-grid"></div>
+        <button id="load-more-gallery" class="load-more">Load More</button>
       </div>
     </div>
   </main>

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
           <p>Discover and organize images by categories in a Pinterest-style gallery.</p>
         </div>
         <div class="pinterest-grid" id="home-grid"></div>
+        <button id="load-more-home" class="load-more">Load More</button>
       </div>
     </div>
   </main>

--- a/script.js
+++ b/script.js
@@ -9,6 +9,14 @@ const modalImage = document.getElementById('modal-image');
 const modalClose = document.querySelector('.modal-close');
 const searchInput = document.querySelector('.search-input');
 const searchSuggestions = document.querySelector('.search-suggestions');
+const loadMoreHome = document.getElementById('load-more-home');
+const loadMoreGallery = document.getElementById('load-more-gallery');
+
+const ITEMS_PER_PAGE = 20;
+let homeImages = [];
+let homePageIndex = 0;
+let galleryImages = [];
+let galleryPageIndex = 0;
 
 const lazyObserver = new IntersectionObserver((entries, observer) => {
   entries.forEach(entry => {
@@ -22,6 +30,27 @@ const lazyObserver = new IntersectionObserver((entries, observer) => {
 
 function observeImage(img) {
   lazyObserver.observe(img);
+}
+
+function createPinterestItem(image) {
+  const pinterestItem = document.createElement('div');
+  pinterestItem.className = 'pinterest-item fade-in';
+  pinterestItem.innerHTML = `
+      <img data-src="${image.src}" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="Image" class="lazy-image">
+      <div class="image-info">
+        <p class="image-description">${image.description}</p>
+        <span class="image-tag">${image.tag}</span>
+      </div>
+    `;
+  const img = pinterestItem.querySelector('img');
+  observeImage(img);
+  img.addEventListener('click', () => showModal(image.src));
+  const tag = pinterestItem.querySelector('.image-tag');
+  tag.addEventListener('click', () => {
+    console.log('Navigating to gallery.html?tag=', image.tag);
+    window.location.href = `gallery.html?tag=${encodeURIComponent(image.tag)}`;
+  });
+  return pinterestItem;
 }
 
 // Fetch images from images.json
@@ -57,76 +86,78 @@ async function fetchTags() {
   }
 }
 
-// Render home page with all images
+// Render home page with pagination
 async function renderHome() {
   if (!homeGrid) {
     console.log('Not on home page, skipping renderHome');
     return;
   }
-  const images = await fetchImages();
-  if (images.length === 0) {
+  homeImages = await fetchImages();
+  if (homeImages.length === 0) {
     console.warn('No images found for home page');
     homeGrid.innerHTML = '<p>No images available.</p>';
     return;
   }
   homeGrid.innerHTML = '';
-  images.forEach(image => {
-    const pinterestItem = document.createElement('div');
-    pinterestItem.className = 'pinterest-item fade-in';
-    pinterestItem.innerHTML = `
-      <img data-src="${image.src}" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="Image" class="lazy-image">
-      <div class="image-info">
-        <p class="image-description">${image.description}</p>
-        <span class="image-tag">${image.tag}</span>
-      </div>
-    `;
-    const img = pinterestItem.querySelector('img');
-    observeImage(img);
-    img.addEventListener('click', () => showModal(image.src));
-    const tag = pinterestItem.querySelector('.image-tag');
-    tag.addEventListener('click', () => {
-      console.log('Navigating to gallery.html?tag=', image.tag);
-      window.location.href = `gallery.html?tag=${encodeURIComponent(image.tag)}`;
-    });
-    homeGrid.appendChild(pinterestItem);
-  });
+  homePageIndex = 0;
+  appendHomeImages();
+  if (loadMoreHome) {
+    loadMoreHome.addEventListener('click', appendHomeImages);
+  }
 }
 
-// Render gallery for a specific tag
+function appendHomeImages() {
+  const start = homePageIndex * ITEMS_PER_PAGE;
+  const nextImages = homeImages.slice(start, start + ITEMS_PER_PAGE);
+  nextImages.forEach(image => {
+    homeGrid.appendChild(createPinterestItem(image));
+  });
+  homePageIndex++;
+  if (loadMoreHome) {
+    if (homePageIndex * ITEMS_PER_PAGE >= homeImages.length) {
+      loadMoreHome.style.display = 'none';
+    } else {
+      loadMoreHome.style.display = 'block';
+    }
+  }
+}
+
+// Render gallery for a specific tag with pagination
 async function renderGallery(tag) {
   if (!pinterestGrid) {
     console.log('Not on gallery page, skipping renderGallery');
     return;
   }
   const images = await fetchImages();
-  const filteredImages = images.filter(image => image.tag.toLowerCase() === tag.toLowerCase());
-  console.log(`Filtered Images for tag "${tag}":`, filteredImages);
+  galleryImages = images.filter(image => image.tag.toLowerCase() === tag.toLowerCase());
+  console.log(`Filtered Images for tag "${tag}":`, galleryImages);
   pinterestGrid.innerHTML = '';
-  if (filteredImages.length === 0) {
+  galleryPageIndex = 0;
+  if (galleryImages.length === 0) {
     console.warn(`No images found for tag "${tag}"`);
     pinterestGrid.innerHTML = `<p>No images found for tag "${tag}".</p>`;
     return;
   }
-  filteredImages.forEach(image => {
-    const pinterestItem = document.createElement('div');
-    pinterestItem.className = 'pinterest-item fade-in';
-    pinterestItem.innerHTML = `
-      <img data-src="${image.src}" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" alt="Image" class="lazy-image">
-      <div class="image-info">
-        <p class="image-description">${image.description}</p>
-        <span class="image-tag">${image.tag}</span>
-      </div>
-    `;
-    const img = pinterestItem.querySelector('img');
-    observeImage(img);
-    img.addEventListener('click', () => showModal(image.src));
-    const tagElement = pinterestItem.querySelector('.image-tag');
-    tagElement.addEventListener('click', () => {
-      console.log('Navigating to gallery.html?tag=', image.tag);
-      window.location.href = `gallery.html?tag=${encodeURIComponent(image.tag)}`;
-    });
-    pinterestGrid.appendChild(pinterestItem);
+  appendGalleryImages();
+  if (loadMoreGallery) {
+    loadMoreGallery.addEventListener('click', appendGalleryImages);
+  }
+}
+
+function appendGalleryImages() {
+  const start = galleryPageIndex * ITEMS_PER_PAGE;
+  const nextImages = galleryImages.slice(start, start + ITEMS_PER_PAGE);
+  nextImages.forEach(image => {
+    pinterestGrid.appendChild(createPinterestItem(image));
   });
+  galleryPageIndex++;
+  if (loadMoreGallery) {
+    if (galleryPageIndex * ITEMS_PER_PAGE >= galleryImages.length) {
+      loadMoreGallery.style.display = 'none';
+    } else {
+      loadMoreGallery.style.display = 'block';
+    }
+  }
 }
 
 // Show modal with image preview

--- a/styles.css
+++ b/styles.css
@@ -78,6 +78,22 @@ header {
     color: #374151;
 }
 
+.load-more {
+    display: block;
+    margin: 40px auto;
+    padding: 8px 16px;
+    background: #d97706;
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    font-weight: 500;
+}
+
+.load-more:hover {
+    background: #b45309;
+}
+
 /* Search Bar */
 .search-container {
     position: relative;


### PR DESCRIPTION
## Summary
- Add "Load More" buttons and styles for home and tag gallery pages
- Implement client-side pagination, rendering images in batches to improve loading speed
- Introduce helper to build image cards and reuse in pagination

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aabc35bad48320aef829f605a97574