### PR TITLE
feat: add explore tags view

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -23,6 +23,8 @@
     </div>
   </header>
 
+  <div class="explore-tags" id="explore-tags"></div>
+
   <main>
     <div class="container">
       <div class="gallery-page">

--- a/index.html
+++ b/index.html
@@ -26,6 +26,8 @@
     </div>
   </header>
 
+  <div class="explore-tags" id="explore-tags"></div>
+
   <main>
     <div class="container">
       <div class="home-page">

--- a/script.js
+++ b/script.js
@@ -11,6 +11,8 @@ const searchInput = document.querySelector('.search-input');
 const searchSuggestions = document.querySelector('.search-suggestions');
 const loadMoreHome = document.getElementById('load-more-home');
 const loadMoreGallery = document.getElementById('load-more-gallery');
+const exploreButton = document.querySelector('.nav-explore');
+const exploreTags = document.getElementById('explore-tags');
 
 const ITEMS_PER_PAGE = 20;
 let homeImages = [];
@@ -254,6 +256,43 @@ async function setupSearch() {
   }
 }
 
+function setupExplore() {
+  if (!exploreButton || !exploreTags) {
+    console.log('Explore elements not found, skipping setupExplore');
+    return;
+  }
+
+  exploreButton.addEventListener('click', async (e) => {
+    e.preventDefault();
+    if (exploreTags.classList.contains('active')) {
+      exploreTags.classList.remove('active');
+      return;
+    }
+    const tags = await fetchTags();
+    exploreTags.innerHTML = '';
+    if (tags.length === 0) {
+      exploreTags.innerHTML = '<p>No tags available.</p>';
+    } else {
+      tags.forEach(tag => {
+        const tagEl = document.createElement('div');
+        tagEl.className = 'explore-tag';
+        tagEl.textContent = tag;
+        tagEl.addEventListener('click', () => {
+          window.location.href = `gallery.html?tag=${encodeURIComponent(tag)}`;
+        });
+        exploreTags.appendChild(tagEl);
+      });
+    }
+    exploreTags.classList.add('active');
+  });
+
+  document.addEventListener('click', (e) => {
+    if (!e.target.closest('.nav-explore') && !e.target.closest('#explore-tags')) {
+      exploreTags.classList.remove('active');
+    }
+  });
+}
+
 // Initialize based on page
 async function init() {
   const urlParams = new URLSearchParams(window.location.search);
@@ -276,4 +315,5 @@ async function init() {
   }
 }
 
+setupExplore();
 init();

--- a/styles.css
+++ b/styles.css
@@ -147,6 +147,41 @@ header {
     background: #f3f4f6;
 }
 
+/* Explore Tags */
+.explore-tags {
+    position: fixed;
+    top: 72px;
+    left: 0;
+    right: 0;
+    background: #fff;
+    border-top: 1px solid #e5e7eb;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    padding: 16px;
+    display: none;
+    flex-wrap: wrap;
+    gap: 12px;
+    z-index: 150;
+}
+
+.explore-tags.active {
+    display: flex;
+}
+
+.explore-tag {
+    background: #f3f4f6;
+    border-radius: 16px;
+    padding: 6px 12px;
+    cursor: pointer;
+    font-size: 14px;
+    color: #2f2f2f;
+    text-transform: capitalize;
+    transition: background 0.2s ease;
+}
+
+.explore-tag:hover {
+    background: #e5e7eb;
+}
+
 /* Main Content */
 main {
     min-height: calc(100vh - 200px);


### PR DESCRIPTION
## Summary
- show all available tags when clicking Explore
- allow selecting a tag to jump to the gallery page for that tag
- add styles for explore tag overlay

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf39368d483208eece9ed51beb8ae